### PR TITLE
Adjusting #! to call /usr/bin/env python not /user/bin/python.

### DIFF
--- a/crawlic.py
+++ b/crawlic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from lib.pholcidae import Pholcidae
 import argparse


### PR DESCRIPTION
This adjustments makes the script select the python on the active
users path. Amoung other things, this makes OSX with Homebrew worky.